### PR TITLE
Add CoffeeOps meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This is a resource for anyone visiting Denver or people recently new to the Denv
 * [Fullstack](https://www.meetup.com/fullstack/)
 * [Girl Develop It - Boulder](https://www.girldevelopit.com/chapters/boulder)
 * [Girl Develop It - Denver](https://www.girldevelopit.com/chapters/denver)
-* [Kegs With Legs](http://adclubdenver.com/Kegs-With-Legs)
 * [Learn To Code Front Range](https://www.meetup.com/Learn-To-Code-Front-Range/)
 * [Learn To Code Colorado](https://www.meetup.com/Learn-To-Code-Colorado/)
 * [Mile High Gophers - Denver (Go Lang)](https://www.meetup.com/Denver-Go-Language-User-Group/)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a resource for anyone visiting Denver or people recently new to the Denv
 ## Meetups
 * [Boulder Denver Big Data](https://www.meetup.com/Boulder-Denver-Big-Data/)
 * [Code for Denver](https://www.meetup.com/CodeForDenver/)
+* [CoffeeOps](https://www.meetup.com/Denver-CoffeeOps/)
 * [CreativeMornings - Denver](https://creativemornings.com/cities/den)
 * [Denhac](https://denhac.org/page/homepage) (on [meetup.com](https://www.meetup.com/denhac-hackerspace/))
 * [Denver CoffeeOps](https://www.meetup.com/Denver-CoffeeOps/)
@@ -51,7 +52,7 @@ This is a resource for anyone visiting Denver or people recently new to the Denv
 ## Boulder & Denver
 Boulder and Denver are two distinct cities that are very near to each other, and they are both tech hubs. Denver is extremely large compared to Boulder, and Boulder is a lot more residential with Denver having more of a commercial and industrial complex built around it as well as residential. Most Boulder tech offices are centered around the Boulder downtown area, the mainstay of which is Pearl Street. Larger tech companies will rent more office space on the east side of town where there are less residential neighborhoods and more commerical real estate. Denver tech is centered Downtown or in the DTC (Denver Tech Center).
 
-The two cities are only about about [30 minutes away](https://www.google.com/maps/dir/Denver,+CO/Boulder,+CO/@39.8770264,-105.2662174,11z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x876b80aa231f17cf:0x118ef4f8278a36d6!2m2!1d-104.990251!2d39.7392358!1m5!1m1!1s0x876b8d4e278dafd3:0xc8393b7ca01b8058!2m2!1d-105.2705456!2d40.0149856!3e0) from each other, but that can turn into almost an hour during rush hour. Typically, commuting out of Denver into Boulder everyday is the worse of the two options, whereas commuting out of Boulder into Denver is relatively smooth sailing. Boulder is extremely expensive to live in, so traffic into Boulder for the work day and out at the end of the day is pretty extreme as a lot of Boulders workforce lives outside the city.
+The two cities are only about about [30 minutes away](https://www.google.com/maps/dir/Denver,+CO/Boulder,+CO/@39.8770264,-105.2662174,11z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x876b80aa231f17cf:0x118ef4f8278a36d6!2m2!1d-104.990251!2d39.7392358!1m5!1m1!1s0x876b8d4e278dafd3:0xc8393b7ca01b8058!2m2!1d-105.2705456!2d40.0149856!3e0) from each other, but that can turn into almost an hour during rush hour. Typically, commuting out of Denver into Boulder everyday is the worse of the two options, whereas commuting out of Boulder into Denver is relatively smooth sailing. Boulder is extremely expensive to live in, so traffic into Boulder for the work day and out at the end of the day is pretty extreme as a lot of Boulder's workforce lives outside the city.
 
 Denver is home to the Auraria campus, which houses University of Colorado at Denver, Metropolitan State University and Community College of Denver on a single, shared campus. Boulder is home to the University of Colorado at Boulder, and has a very "college town" feel to it in areas surrounding the university.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a resource for anyone visiting Denver or people recently new to the Denv
 * [Code for Denver](https://www.meetup.com/CodeForDenver/)
 * [CoffeeOps](https://www.meetup.com/Denver-CoffeeOps/)
 * [CreativeMornings - Denver](https://creativemornings.com/cities/den)
-* [Denhac](https://denhac.org/page/homepage) (on [meetup.com](https://www.meetup.com/denhac-hackerspace/))
+* [Denhac](https://denhac.org) (on [meetup.com](https://www.meetup.com/denhac-hackerspace/))
 * [Denver CoffeeOps](https://www.meetup.com/Denver-CoffeeOps/)
 * [Denver Code Club](https://www.meetup.com/Denver-Code-Club/)
 * [Denver Creative Tech](https://www.meetup.com/denver-creative-tech/)


### PR DESCRIPTION
* Added a link to the CoffeeOps meetup
* Added missing ' in Boulder description
* Updated stale link to old denhac home page
* Removed link to www.adclubdenver.com, it is now being held by a Chinese domain squatter.